### PR TITLE
feat: add intersecion options

### DIFF
--- a/packages/docs/index.html
+++ b/packages/docs/index.html
@@ -392,6 +392,7 @@ vfx.add(el, { shader: "slitScanTransition" });
                         <img
                             src="./vfx-js-logo-no-padding.svg"
                             data-shader="slitScanTransition"
+                            data-threshold="1"
                         />
                     </div>
                 </div>
@@ -405,6 +406,7 @@ vfx.add(el, { shader: "warpTransition" });
                         <img
                             src="./vfx-js-logo-no-padding.svg"
                             data-shader="warpTransition"
+                            data-threshold="1"
                         />
                     </div>
                 </div>
@@ -418,6 +420,7 @@ vfx.add(el, { shader: "pixelateTransition" });
                         <img
                             src="./vfx-js-logo-no-padding.svg"
                             data-shader="pixelateTransition"
+                            data-threshold="1"
                         />
                     </div>
                 </div>

--- a/packages/docs/index.html
+++ b/packages/docs/index.html
@@ -424,6 +424,19 @@ vfx.add(el, { shader: "pixelateTransition" });
                         />
                     </div>
                 </div>
+                <div class="row">
+                    <div class="col">
+                        <pre><code class="language-javascript">
+vfx.add(el, { shader: "focusTransition" });
+                        </code></pre>
+                    </div>
+                    <div class="col">
+                        <img
+                            src="./vfx-js-logo-no-padding.svg"
+                            data-shader="focusTransition"
+                        />
+                    </div>
+                </div>
             </div>
 
             <div>

--- a/packages/docs/src/main.ts
+++ b/packages/docs/src/main.ts
@@ -17,6 +17,7 @@ const shaders: Record<string, string> = {
     uniform vec2 offset;
     uniform float time;
     uniform float enterTime;
+    uniform float leaveTime;
     uniform sampler2D src;
 
     uniform float delay;
@@ -79,7 +80,10 @@ const shaders: Record<string, string> = {
 
     void main (void) {
         vec2 uv = (gl_FragCoord.xy - offset) / resolution;
-        if (enterTime < 1.0) {
+        if (leaveTime > 0.) {
+            float t = clamp(leaveTime - 0.5, 0., 1.);
+            gl_FragColor = glitch(uv) * (1. - t);
+        } else if (enterTime < 1.0) {
             gl_FragColor = slitscan(uv);
         } else {
             gl_FragColor = glitch(uv);
@@ -354,6 +358,9 @@ class App {
             shader: shaders.logo,
             overflow: [0, 3000, 0, 100],
             uniforms: { delay: 0 },
+            intersection: {
+                threshold: 1,
+            },
         });
 
         const tagline = document.getElementById("LogoTagline")!;
@@ -361,6 +368,9 @@ class App {
             shader: shaders.logo,
             overflow: [0, 3000, 0, 1000],
             uniforms: { delay: 0.3 },
+            intersection: {
+                threshold: 1,
+            },
         });
     }
 
@@ -368,8 +378,12 @@ class App {
         const profile = document.getElementById("profile")!;
         this.vfx.add(profile, {
             shader: shaders.logo,
-            overflow: [0, 2000, 0, 1000],
+            overflow: [0, 2000, 0, 2000],
             uniforms: { delay: 0.5 },
+            intersection: {
+                rootMargin: [-100, 0, -100, 0],
+                threshold: 1,
+            },
         });
     }
 }

--- a/packages/docs/src/main.ts
+++ b/packages/docs/src/main.ts
@@ -229,6 +229,11 @@ class App {
                 shader,
                 overflow: parseFloat(e.getAttribute("data-overflow") ?? "0"),
                 uniforms,
+                intersection: {
+                    threshold: parseFloat(
+                        e.getAttribute("data-threshold") ?? "0",
+                    ),
+                },
             });
         }
     }

--- a/packages/vfx-js/src/constants.ts
+++ b/packages/vfx-js/src/constants.ts
@@ -578,13 +578,23 @@ export const shaders: Record<ShaderPreset, string> = {
     uniform vec2 offset;
     uniform float time;
     uniform float enterTime;
+    uniform float leaveTime;
     uniform sampler2D src;
+
+    #define DURATION 1.0
 
     void main (void) {
         vec2 uv = (gl_FragCoord.xy - offset) / resolution;
 
-        if (enterTime < 1.5) {
-            float t = enterTime / 1.5;
+        float t1 = enterTime / DURATION;
+        float t2 = leaveTime / DURATION;
+        float t = clamp(min(t1, 1. - t2), 0., 1.);
+
+        if (t == 0.) {
+            discard;
+        }
+
+        if (t < 1.) {
             uv.x += sin(floor(uv.y * 300.)) * 3. * exp(t * -10.);
         }
 
@@ -597,14 +607,30 @@ export const shaders: Record<ShaderPreset, string> = {
     uniform vec2 offset;
     uniform float time;
     uniform float enterTime;
+    uniform float leaveTime;
     uniform sampler2D src;
+
+    #define DURATION 1.0
 
     void main (void) {
         vec2 uv = (gl_FragCoord.xy - offset) / resolution;
 
-        if (enterTime < 1.5) {
-            float t = 1. - enterTime / 1.5;
-            uv.y = uv.y > t ? uv.y : t;
+        float t1 = enterTime / DURATION;
+        float t2 = leaveTime / DURATION;
+
+        // Do not render before enter or after leave
+        if (t1 < 0. || 1. < t2) {
+            discard;
+        }
+
+        if (0. < t2) {
+            // Leaving
+            float t = 1. - t2;
+            uv.y = uv.y < t ? uv.y : t;
+        } else if (t1 < 1.) {
+            // Entering
+            float t = 1. - t1;
+            uv.y = uv.y < t ? t : uv.y;
         }
 
         gl_FragColor = texture2D(src, uv);
@@ -616,14 +642,21 @@ export const shaders: Record<ShaderPreset, string> = {
     uniform vec2 offset;
     uniform float time;
     uniform float enterTime;
+    uniform float leaveTime;
     uniform sampler2D src;
+
+    #define DURATION 1.0
 
     void main (void) {
         vec2 uv = (gl_FragCoord.xy - offset) / resolution;
 
-        if (enterTime < 1.5) {
-            float t = enterTime / 1.5;
+        float t1 = enterTime / DURATION;
+        float t2 = leaveTime / DURATION;
+        float t = clamp(min(t1, 1. - t2), 0., 1.);
 
+        if (t == 0.) {
+            discard;
+        } else if (t < 1.) {
             float b = floor(t * 64.);
             uv = (floor(uv * b) + .5) / b;
         }

--- a/packages/vfx-js/src/constants.ts
+++ b/packages/vfx-js/src/constants.ts
@@ -25,7 +25,8 @@ export type ShaderPreset =
     | "halftone"
     | "slitScanTransition"
     | "warpTransition"
-    | "pixelateTransition";
+    | "pixelateTransition"
+    | "focusTransition";
 
 /**
  * Shader code for presets.
@@ -662,6 +663,25 @@ export const shaders: Record<ShaderPreset, string> = {
         }
 
         gl_FragColor = texture2D(src, uv);
+    }
+    `,
+    focusTransition: `
+    precision highp float;
+    uniform vec2 resolution;
+    uniform vec2 offset;
+    uniform float time;
+    uniform float intersection;
+    uniform sampler2D src;
+
+    void main (void) {
+        vec2 uv = (gl_FragCoord.xy - offset) / resolution;
+        float t = smoothstep(0., 1., intersection);
+
+        gl_FragColor = mix(
+            texture2D(src, uv + vec2(1. - t, 0)),
+            texture2D(src, uv + vec2(-(1. - t), 0)),
+            0.5
+        ) * intersection;
     }
     `,
 };

--- a/packages/vfx-js/src/rect.test.ts
+++ b/packages/vfx-js/src/rect.test.ts
@@ -1,5 +1,5 @@
 import { expect, describe, test } from "vitest";
-import { createRect, growRect, shrinkRect } from "./rect";
+import { createRect, getIntersection, growRect, shrinkRect } from "./rect";
 
 describe("createRect", () => {
     test("single number", () => {
@@ -95,5 +95,35 @@ describe("shrinkRect", () => {
             bottom: 201,
             left: 99,
         });
+    });
+});
+
+describe("getIntersection", () => {
+    test("no intersection", () => {
+        const a = createRect([0, 1, 1, 0]);
+        const b = createRect([0, 2, 1, 1]);
+        expect(getIntersection(a, b)).toBe(0);
+    });
+    test("full intersection", () => {
+        expect(
+            getIntersection(createRect([0, 1, 1, 0]), createRect([0, 1, 1, 0])),
+        ).toBe(1);
+        expect(
+            getIntersection(
+                createRect([0, 10, 10, 1]),
+                createRect([1, 2, 2, 1]),
+            ),
+        ).toBe(1);
+    });
+    test("partial intersection", () => {
+        expect(
+            getIntersection(createRect([0, 2, 1, 0]), createRect([0, 1, 1, 0])),
+        ).toBe(1); // target is fully covered by container
+        expect(
+            getIntersection(createRect([0, 1, 1, 0]), createRect([0, 2, 1, 0])),
+        ).toBe(0.5); // 50% of target is covered by container
+        expect(
+            getIntersection(createRect([1, 2, 2, 1]), createRect([0, 2, 2, 0])),
+        ).toBe(0.25); // 25%
     });
 });

--- a/packages/vfx-js/src/rect.test.ts
+++ b/packages/vfx-js/src/rect.test.ts
@@ -1,0 +1,99 @@
+import { expect, describe, test } from "vitest";
+import { createRect, growRect, shrinkRect } from "./rect";
+
+describe("createRect", () => {
+    test("single number", () => {
+        expect(createRect(1)).toStrictEqual({
+            top: 1,
+            right: 1,
+            bottom: 1,
+            left: 1,
+        });
+    });
+
+    test("array", () => {
+        expect(createRect([1, 2, 3, 4])).toStrictEqual({
+            top: 1,
+            right: 2,
+            bottom: 3,
+            left: 4,
+        });
+    });
+
+    test("object", () => {
+        expect(
+            createRect({ top: 1, right: 2, bottom: 3, left: 4 }),
+        ).toStrictEqual({
+            top: 1,
+            right: 2,
+            bottom: 3,
+            left: 4,
+        });
+    });
+});
+
+describe("growRect", () => {
+    test("positive values", () => {
+        const a = {
+            top: 100,
+            right: 200,
+            bottom: 200,
+            left: 100,
+        };
+        const b = createRect(1);
+        expect(growRect(a, b)).toStrictEqual({
+            top: 99,
+            right: 201,
+            bottom: 201,
+            left: 99,
+        });
+    });
+    test("negative values", () => {
+        const a = {
+            top: 100,
+            right: 200,
+            bottom: 200,
+            left: 100,
+        };
+        const b = createRect(-1);
+        expect(growRect(a, b)).toStrictEqual({
+            top: 101,
+            right: 199,
+            bottom: 199,
+            left: 101,
+        });
+    });
+});
+
+describe("shrinkRect", () => {
+    test("positive values", () => {
+        const a = {
+            top: 100,
+            right: 200,
+            bottom: 200,
+            left: 100,
+        };
+        const b = createRect(1);
+        expect(shrinkRect(a, b)).toStrictEqual({
+            top: 101,
+            right: 199,
+            bottom: 199,
+            left: 101,
+        });
+    });
+    test("negative values", () => {
+        const a = {
+            top: 100,
+            right: 200,
+            bottom: 200,
+            left: 100,
+        };
+        const b = createRect(-1);
+        expect(shrinkRect(a, b)).toStrictEqual({
+            top: 99,
+            right: 201,
+            bottom: 201,
+            left: 99,
+        });
+    });
+});

--- a/packages/vfx-js/src/rect.ts
+++ b/packages/vfx-js/src/rect.ts
@@ -53,3 +53,21 @@ export function createRect(r: RectOpts): Rect {
         left: r.left ?? 0,
     };
 }
+
+export function growRect(a: Rect, b: Rect): Rect {
+    return {
+        top: a.top - b.top,
+        right: a.right + b.right,
+        bottom: a.bottom + b.bottom,
+        left: a.left - b.left,
+    };
+}
+
+export function shrinkRect(a: Rect, b: Rect): Rect {
+    return {
+        top: a.top + b.top,
+        right: a.right - b.right,
+        bottom: a.bottom - b.bottom,
+        left: a.left + b.left,
+    };
+}

--- a/packages/vfx-js/src/rect.ts
+++ b/packages/vfx-js/src/rect.ts
@@ -71,3 +71,23 @@ export function shrinkRect(a: Rect, b: Rect): Rect {
         left: a.left + b.left,
     };
 }
+
+function clamp(x: number, xmin: number, xmax: number): number {
+    return Math.min(Math.max(x, xmin), xmax);
+}
+
+/**
+ * Calculate the ratio of the intersection between two Rect objects.
+ * It returns a number between 0 and 1.
+ */
+export function getIntersection(container: Rect, target: Rect): number {
+    const targetL = clamp(target.left, container.left, container.right);
+    const targetR = clamp(target.right, container.left, container.right);
+    const w = (targetR - targetL) / (target.right - target.left);
+
+    const targetT = clamp(target.top, container.top, container.bottom);
+    const targetB = clamp(target.bottom, container.top, container.bottom);
+    const h = (targetB - targetT) / (target.bottom - target.top);
+
+    return w * h;
+}

--- a/packages/vfx-js/src/rect.ts
+++ b/packages/vfx-js/src/rect.ts
@@ -1,0 +1,55 @@
+/**
+ * top-left origin rect.
+ * Subset of DOMRect, which is returned by `HTMLElement.getBoundingClientRect()`.
+ * @internal
+ */
+export type Rect = {
+    left: number;
+    right: number;
+    top: number;
+    bottom: number;
+};
+
+export function rect(
+    top: number,
+    right: number,
+    bottom: number,
+    left: number,
+): Rect {
+    return { top, right, bottom, left };
+}
+
+export const RECT_ZERO: Rect = rect(0, 0, 0, 0);
+
+/**
+ * Values to determine a rectangle area for margin, padding etc.
+ */
+export type RectOpts =
+    | number
+    | [top: number, right: number, bottom: number, left: number]
+    | { top?: number; right?: number; bottom?: number; left?: number };
+
+export function createRect(r: RectOpts): Rect {
+    if (typeof r === "number") {
+        return {
+            top: r,
+            right: r,
+            bottom: r,
+            left: r,
+        };
+    }
+    if (Array.isArray(r)) {
+        return {
+            top: r[0],
+            right: r[1],
+            bottom: r[2],
+            left: r[3],
+        };
+    }
+    return {
+        top: r.top ?? 0,
+        right: r.right ?? 0,
+        bottom: r.bottom ?? 0,
+        left: r.left ?? 0,
+    };
+}

--- a/packages/vfx-js/src/types.ts
+++ b/packages/vfx-js/src/types.ts
@@ -102,6 +102,7 @@ export type VFXProps = {
 
     intersection?: {
         threshold?: number;
+        rootMargin?: RectOpts;
     };
 
     /**
@@ -194,4 +195,5 @@ export type VFXElement = {
 
 export type VFXElementIntersection = {
     threshold: number;
+    rootMargin: Rect;
 };

--- a/packages/vfx-js/src/types.ts
+++ b/packages/vfx-js/src/types.ts
@@ -176,6 +176,7 @@ export type VFXElement = {
     type: VFXElementType;
     element: HTMLElement;
     isInViewport: boolean;
+    isInTransitionArea: boolean;
     width: number;
     height: number;
     scene: THREE.Scene;

--- a/packages/vfx-js/src/types.ts
+++ b/packages/vfx-js/src/types.ts
@@ -176,7 +176,7 @@ export type VFXElement = {
     type: VFXElementType;
     element: HTMLElement;
     isInViewport: boolean;
-    isInTransitionArea: boolean;
+    isInLogicalViewport: boolean;
     width: number;
     height: number;
     scene: THREE.Scene;

--- a/packages/vfx-js/src/types.ts
+++ b/packages/vfx-js/src/types.ts
@@ -181,12 +181,8 @@ export type VFXElement = {
     leaveTime: number;
     release: number;
     isGif: boolean;
-    overflow: VFXElementOverflow;
+    isFullScreen: boolean;
+    overflow: Rect;
     originalOpacity: number;
     zIndex: number;
 };
-
-/**
- * @internal
- */
-export type VFXElementOverflow = "fullscreen" | Rect;

--- a/packages/vfx-js/src/types.ts
+++ b/packages/vfx-js/src/types.ts
@@ -100,6 +100,10 @@ export type VFXProps = {
      */
     overlay?: true | number;
 
+    intersection?: {
+        threshold?: number;
+    };
+
     /**
      * Allow shader outputs to oveflow the original element area. (Default: `0`)
      *
@@ -183,6 +187,11 @@ export type VFXElement = {
     isGif: boolean;
     isFullScreen: boolean;
     overflow: Rect;
+    intersection: VFXElementIntersection;
     originalOpacity: number;
     zIndex: number;
+};
+
+export type VFXElementIntersection = {
+    threshold: number;
 };

--- a/packages/vfx-js/src/types.ts
+++ b/packages/vfx-js/src/types.ts
@@ -100,8 +100,15 @@ export type VFXProps = {
      */
     overlay?: true | number;
 
+    /**
+     * Options to control transition behaviour.
+     * These properties work similarly to the IntersectionObsrever options.
+     */
     intersection?: {
+        /** Threshold for the element to be considered "entered" to the viewport. */
         threshold?: number;
+
+        /** Margin of the viewport to be used in intersection calculcation. */
         rootMargin?: RectOpts;
     };
 

--- a/packages/vfx-js/src/types.ts
+++ b/packages/vfx-js/src/types.ts
@@ -1,5 +1,6 @@
 import THREE from "three";
 import { ShaderPreset } from "./constants.js";
+import { Rect, RectOpts } from "./rect.js";
 
 /**
  * Options to initialize `VFX` class.
@@ -113,11 +114,7 @@ export type VFXProps = {
      * If you pass an object like `<VFXImg overflow={{ top: 100 }} />`,
      * REACT-VFX will add paddings only to the given direction (only to the `top` in this example).
      */
-    overflow?:
-        | true
-        | number
-        | [top: number, right: number, bottom: number, left: number]
-        | { top?: number; right?: number; bottom?: number; left?: number };
+    overflow?: true | RectOpts;
 
     /**
      * Texture wrapping mode. (Default: `"repeat"`)
@@ -192,6 +189,4 @@ export type VFXElement = {
 /**
  * @internal
  */
-export type VFXElementOverflow =
-    | "fullscreen"
-    | { top: number; right: number; bottom: number; left: number };
+export type VFXElementOverflow = "fullscreen" | Rect;

--- a/packages/vfx-js/src/vfx-player.test.ts
+++ b/packages/vfx-js/src/vfx-player.test.ts
@@ -115,7 +115,7 @@ describe("isRectInViewport", () => {
 
     test("no overflow", () => {
         expect(
-            isRectInViewport(rect(0, 0, 1, 1), rect(0, 0, 1, 1), pad(0)),
+            isRectInViewport(rect(0, 0, 1, 1), rect(0, 0, 1, 1), pad(0), 0),
         ).toBe(true);
 
         // adjacent rects
@@ -124,6 +124,7 @@ describe("isRectInViewport", () => {
                 rect(0, 0, 1, 1),
                 rect(-1, 0, 1, 1), // left
                 pad(0),
+                0,
             ),
         ).toBe(true);
         expect(
@@ -131,6 +132,7 @@ describe("isRectInViewport", () => {
                 rect(0, 0, 1, 1),
                 rect(1, 0, 1, 1), // right
                 pad(0),
+                0,
             ),
         ).toBe(true);
         expect(
@@ -138,6 +140,7 @@ describe("isRectInViewport", () => {
                 rect(0, 0, 1, 1),
                 rect(0, -1, 1, 1), // top
                 pad(0),
+                0,
             ),
         ).toBe(true);
         expect(
@@ -145,6 +148,7 @@ describe("isRectInViewport", () => {
                 rect(0, 0, 1, 1),
                 rect(0, 1, 1, 1), // bottom
                 pad(0),
+                0,
             ),
         ).toBe(true);
 
@@ -154,6 +158,7 @@ describe("isRectInViewport", () => {
                 rect(0, 0, 1, 1),
                 rect(-2, 0, 1, 1), // 1px left
                 pad(0),
+                0,
             ),
         ).toBe(false);
         expect(
@@ -161,6 +166,7 @@ describe("isRectInViewport", () => {
                 rect(0, 0, 1, 1),
                 rect(2, 0, 1, 1), // 1px right
                 pad(0),
+                0,
             ),
         ).toBe(false);
         expect(
@@ -168,6 +174,7 @@ describe("isRectInViewport", () => {
                 rect(0, 0, 1, 1),
                 rect(0, -2, 1, 1), // 1px top
                 pad(0),
+                0,
             ),
         ).toBe(false);
         expect(
@@ -175,13 +182,14 @@ describe("isRectInViewport", () => {
                 rect(0, 0, 1, 1),
                 rect(0, 2, 1, 1), // 1px bottom
                 pad(0),
+                0,
             ),
         ).toBe(false);
     });
 
     test("with overflow", () => {
         expect(
-            isRectInViewport(rect(0, 0, 1, 1), rect(0, 0, 1, 1), pad(1)),
+            isRectInViewport(rect(0, 0, 1, 1), rect(0, 0, 1, 1), pad(1), 0),
         ).toBe(true);
 
         // adjacent rects
@@ -190,6 +198,7 @@ describe("isRectInViewport", () => {
                 rect(0, 0, 1, 1),
                 rect(-1, 0, 1, 1), // left
                 pad(1),
+                0,
             ),
         ).toBe(true);
         expect(
@@ -197,6 +206,7 @@ describe("isRectInViewport", () => {
                 rect(0, 0, 1, 1),
                 rect(1, 0, 1, 1), // right
                 pad(1),
+                0,
             ),
         ).toBe(true);
         expect(
@@ -204,6 +214,7 @@ describe("isRectInViewport", () => {
                 rect(0, 0, 1, 1),
                 rect(0, -1, 1, 1), // top
                 pad(1),
+                0,
             ),
         ).toBe(true);
         expect(
@@ -211,6 +222,7 @@ describe("isRectInViewport", () => {
                 rect(0, 0, 1, 1),
                 rect(0, 1, 1, 1), // bottom
                 pad(1),
+                0,
             ),
         ).toBe(true);
 
@@ -220,6 +232,7 @@ describe("isRectInViewport", () => {
                 rect(0, 0, 1, 1),
                 rect(-2, 0, 1, 1), // 1px left
                 pad(1),
+                0,
             ),
         ).toBe(true);
         expect(
@@ -227,6 +240,7 @@ describe("isRectInViewport", () => {
                 rect(0, 0, 1, 1),
                 rect(2, 0, 1, 1), // 1px right
                 pad(1),
+                0,
             ),
         ).toBe(true);
         expect(
@@ -234,6 +248,7 @@ describe("isRectInViewport", () => {
                 rect(0, 0, 1, 1),
                 rect(0, -2, 1, 1), // 1px top
                 pad(1),
+                0,
             ),
         ).toBe(true);
         expect(
@@ -241,6 +256,7 @@ describe("isRectInViewport", () => {
                 rect(0, 0, 1, 1),
                 rect(0, 2, 1, 1), // 1px bottom
                 pad(1),
+                0,
             ),
         ).toBe(true);
 
@@ -250,6 +266,7 @@ describe("isRectInViewport", () => {
                 rect(0, 0, 1, 1),
                 rect(-3, 0, 1, 1), // 2px left
                 pad(1),
+                0,
             ),
         ).toBe(false);
         expect(
@@ -257,6 +274,7 @@ describe("isRectInViewport", () => {
                 rect(0, 0, 1, 1),
                 rect(3, 0, 1, 1), // 2px right
                 pad(1),
+                0,
             ),
         ).toBe(false);
         expect(
@@ -264,6 +282,7 @@ describe("isRectInViewport", () => {
                 rect(0, 0, 1, 1),
                 rect(0, -3, 1, 1), // 2px top
                 pad(1),
+                0,
             ),
         ).toBe(false);
         expect(
@@ -271,6 +290,7 @@ describe("isRectInViewport", () => {
                 rect(0, 0, 1, 1),
                 rect(0, 3, 1, 1), // 2px bottom
                 pad(1),
+                0,
             ),
         ).toBe(false);
     });

--- a/packages/vfx-js/src/vfx-player.test.ts
+++ b/packages/vfx-js/src/vfx-player.test.ts
@@ -126,7 +126,7 @@ describe("isRectInViewport", () => {
                 pad(0),
                 0,
             ),
-        ).toBe(true);
+        ).toBe(false);
         expect(
             isRectInViewport(
                 rect(0, 0, 1, 1),
@@ -134,7 +134,7 @@ describe("isRectInViewport", () => {
                 pad(0),
                 0,
             ),
-        ).toBe(true);
+        ).toBe(false);
         expect(
             isRectInViewport(
                 rect(0, 0, 1, 1),
@@ -142,7 +142,7 @@ describe("isRectInViewport", () => {
                 pad(0),
                 0,
             ),
-        ).toBe(true);
+        ).toBe(false);
         expect(
             isRectInViewport(
                 rect(0, 0, 1, 1),
@@ -150,7 +150,7 @@ describe("isRectInViewport", () => {
                 pad(0),
                 0,
             ),
-        ).toBe(true);
+        ).toBe(false);
 
         // distant rects
         expect(
@@ -234,7 +234,7 @@ describe("isRectInViewport", () => {
                 pad(1),
                 0,
             ),
-        ).toBe(true);
+        ).toBe(false);
         expect(
             isRectInViewport(
                 rect(0, 0, 1, 1),
@@ -242,7 +242,7 @@ describe("isRectInViewport", () => {
                 pad(1),
                 0,
             ),
-        ).toBe(true);
+        ).toBe(false);
         expect(
             isRectInViewport(
                 rect(0, 0, 1, 1),
@@ -250,7 +250,7 @@ describe("isRectInViewport", () => {
                 pad(1),
                 0,
             ),
-        ).toBe(true);
+        ).toBe(false);
         expect(
             isRectInViewport(
                 rect(0, 0, 1, 1),
@@ -258,7 +258,7 @@ describe("isRectInViewport", () => {
                 pad(1),
                 0,
             ),
-        ).toBe(true);
+        ).toBe(false);
 
         // more distant rects
         expect(

--- a/packages/vfx-js/src/vfx-player.test.ts
+++ b/packages/vfx-js/src/vfx-player.test.ts
@@ -105,25 +105,16 @@ describe("isRectInViewport", () => {
         };
     };
 
-    type Pad = Parameters<typeof isRectInViewport>[2];
-    const pad = (t: number): Pad => ({
-        left: t,
-        right: t,
-        top: t,
-        bottom: t,
-    });
-
     test("no overflow", () => {
-        expect(
-            isRectInViewport(rect(0, 0, 1, 1), rect(0, 0, 1, 1), pad(0), 0),
-        ).toBe(true);
+        expect(isRectInViewport(rect(0, 0, 1, 1), rect(0, 0, 1, 1), 0)).toBe(
+            true,
+        );
 
         // adjacent rects
         expect(
             isRectInViewport(
                 rect(0, 0, 1, 1),
                 rect(-1, 0, 1, 1), // left
-                pad(0),
                 0,
             ),
         ).toBe(true);
@@ -131,7 +122,6 @@ describe("isRectInViewport", () => {
             isRectInViewport(
                 rect(0, 0, 1, 1),
                 rect(1, 0, 1, 1), // right
-                pad(0),
                 0,
             ),
         ).toBe(true);
@@ -139,7 +129,6 @@ describe("isRectInViewport", () => {
             isRectInViewport(
                 rect(0, 0, 1, 1),
                 rect(0, -1, 1, 1), // top
-                pad(0),
                 0,
             ),
         ).toBe(true);
@@ -147,7 +136,6 @@ describe("isRectInViewport", () => {
             isRectInViewport(
                 rect(0, 0, 1, 1),
                 rect(0, 1, 1, 1), // bottom
-                pad(0),
                 0,
             ),
         ).toBe(true);
@@ -157,7 +145,6 @@ describe("isRectInViewport", () => {
             isRectInViewport(
                 rect(0, 0, 1, 1),
                 rect(-2, 0, 1, 1), // 1px left
-                pad(0),
                 0,
             ),
         ).toBe(false);
@@ -165,7 +152,6 @@ describe("isRectInViewport", () => {
             isRectInViewport(
                 rect(0, 0, 1, 1),
                 rect(2, 0, 1, 1), // 1px right
-                pad(0),
                 0,
             ),
         ).toBe(false);
@@ -173,7 +159,6 @@ describe("isRectInViewport", () => {
             isRectInViewport(
                 rect(0, 0, 1, 1),
                 rect(0, -2, 1, 1), // 1px top
-                pad(0),
                 0,
             ),
         ).toBe(false);
@@ -181,115 +166,6 @@ describe("isRectInViewport", () => {
             isRectInViewport(
                 rect(0, 0, 1, 1),
                 rect(0, 2, 1, 1), // 1px bottom
-                pad(0),
-                0,
-            ),
-        ).toBe(false);
-    });
-
-    test("with overflow", () => {
-        expect(
-            isRectInViewport(rect(0, 0, 1, 1), rect(0, 0, 1, 1), pad(1), 0),
-        ).toBe(true);
-
-        // adjacent rects
-        expect(
-            isRectInViewport(
-                rect(0, 0, 1, 1),
-                rect(-1, 0, 1, 1), // left
-                pad(1),
-                0,
-            ),
-        ).toBe(true);
-        expect(
-            isRectInViewport(
-                rect(0, 0, 1, 1),
-                rect(1, 0, 1, 1), // right
-                pad(1),
-                0,
-            ),
-        ).toBe(true);
-        expect(
-            isRectInViewport(
-                rect(0, 0, 1, 1),
-                rect(0, -1, 1, 1), // top
-                pad(1),
-                0,
-            ),
-        ).toBe(true);
-        expect(
-            isRectInViewport(
-                rect(0, 0, 1, 1),
-                rect(0, 1, 1, 1), // bottom
-                pad(1),
-                0,
-            ),
-        ).toBe(true);
-
-        // distant rects
-        expect(
-            isRectInViewport(
-                rect(0, 0, 1, 1),
-                rect(-2, 0, 1, 1), // 1px left
-                pad(1),
-                0,
-            ),
-        ).toBe(true);
-        expect(
-            isRectInViewport(
-                rect(0, 0, 1, 1),
-                rect(2, 0, 1, 1), // 1px right
-                pad(1),
-                0,
-            ),
-        ).toBe(true);
-        expect(
-            isRectInViewport(
-                rect(0, 0, 1, 1),
-                rect(0, -2, 1, 1), // 1px top
-                pad(1),
-                0,
-            ),
-        ).toBe(true);
-        expect(
-            isRectInViewport(
-                rect(0, 0, 1, 1),
-                rect(0, 2, 1, 1), // 1px bottom
-                pad(1),
-                0,
-            ),
-        ).toBe(true);
-
-        // more distant rects
-        expect(
-            isRectInViewport(
-                rect(0, 0, 1, 1),
-                rect(-3, 0, 1, 1), // 2px left
-                pad(1),
-                0,
-            ),
-        ).toBe(false);
-        expect(
-            isRectInViewport(
-                rect(0, 0, 1, 1),
-                rect(3, 0, 1, 1), // 2px right
-                pad(1),
-                0,
-            ),
-        ).toBe(false);
-        expect(
-            isRectInViewport(
-                rect(0, 0, 1, 1),
-                rect(0, -3, 1, 1), // 2px top
-                pad(1),
-                0,
-            ),
-        ).toBe(false);
-        expect(
-            isRectInViewport(
-                rect(0, 0, 1, 1),
-                rect(0, 3, 1, 1), // 2px bottom
-                pad(1),
                 0,
             ),
         ).toBe(false);

--- a/packages/vfx-js/src/vfx-player.test.ts
+++ b/packages/vfx-js/src/vfx-player.test.ts
@@ -1,71 +1,96 @@
 import { expect, describe, test } from "vitest";
 import { isRectInViewport, sanitizeOverflow } from "./vfx-player";
+import { RECT_ZERO } from "./rect";
 
 describe("sanitizeOverflow", () => {
     test('true => "fullscreen"', () => {
-        expect(sanitizeOverflow(true)).toBe("fullscreen");
+        expect(sanitizeOverflow(true)).toStrictEqual([true, RECT_ZERO]);
     });
 
     test("undefined => 0", () => {
-        expect(sanitizeOverflow(undefined)).toStrictEqual({
-            top: 0,
-            right: 0,
-            bottom: 0,
-            left: 0,
-        });
+        expect(sanitizeOverflow(undefined)).toStrictEqual([
+            false,
+            {
+                top: 0,
+                right: 0,
+                bottom: 0,
+                left: 0,
+            },
+        ]);
     });
 
     test("number", () => {
-        expect(sanitizeOverflow(100)).toStrictEqual({
-            top: 100,
-            right: 100,
-            bottom: 100,
-            left: 100,
-        });
+        expect(sanitizeOverflow(100)).toStrictEqual([
+            false,
+            {
+                top: 100,
+                right: 100,
+                bottom: 100,
+                left: 100,
+            },
+        ]);
     });
 
     test("number array", () => {
-        expect(sanitizeOverflow([0, 100, 200, 300])).toStrictEqual({
-            top: 0,
-            right: 100,
-            bottom: 200,
-            left: 300,
-        });
+        expect(sanitizeOverflow([0, 100, 200, 300])).toStrictEqual([
+            false,
+            {
+                top: 0,
+                right: 100,
+                bottom: 200,
+                left: 300,
+            },
+        ]);
     });
 
     test("object", () => {
-        expect(sanitizeOverflow({})).toStrictEqual({
-            top: 0,
-            right: 0,
-            bottom: 0,
-            left: 0,
-        });
-        expect(sanitizeOverflow({ top: 100 })).toStrictEqual({
-            top: 100,
-            right: 0,
-            bottom: 0,
-            left: 0,
-        });
-        expect(sanitizeOverflow({ left: 100 })).toStrictEqual({
-            top: 0,
-            right: 0,
-            bottom: 0,
-            left: 100,
-        });
-        expect(sanitizeOverflow({ top: 100, left: 200 })).toStrictEqual({
-            top: 100,
-            right: 0,
-            bottom: 0,
-            left: 200,
-        });
+        expect(sanitizeOverflow({})).toStrictEqual([
+            false,
+            {
+                top: 0,
+                right: 0,
+                bottom: 0,
+                left: 0,
+            },
+        ]);
+        expect(sanitizeOverflow({ top: 100 })).toStrictEqual([
+            false,
+            {
+                top: 100,
+                right: 0,
+                bottom: 0,
+                left: 0,
+            },
+        ]);
+        expect(sanitizeOverflow({ left: 100 })).toStrictEqual([
+            false,
+            {
+                top: 0,
+                right: 0,
+                bottom: 0,
+                left: 100,
+            },
+        ]);
+        expect(sanitizeOverflow({ top: 100, left: 200 })).toStrictEqual([
+            false,
+            {
+                top: 100,
+                right: 0,
+                bottom: 0,
+                left: 200,
+            },
+        ]);
         expect(
             sanitizeOverflow({ top: 100, right: 200, bottom: 300, left: 400 }),
-        ).toStrictEqual({
-            top: 100,
-            right: 200,
-            bottom: 300,
-            left: 400,
-        });
+        ).toStrictEqual([
+            false,
+            {
+                top: 100,
+                right: 200,
+                bottom: 300,
+                left: 400,
+            },
+        ]);
     });
 });
 

--- a/packages/vfx-js/src/vfx-player.test.ts
+++ b/packages/vfx-js/src/vfx-player.test.ts
@@ -106,37 +106,31 @@ describe("isRectInViewport", () => {
     };
 
     test("no overflow", () => {
-        expect(isRectInViewport(rect(0, 0, 1, 1), rect(0, 0, 1, 1), 0)).toBe(
-            true,
-        );
+        expect(isRectInViewport(rect(0, 0, 1, 1), rect(0, 0, 1, 1))).toBe(true);
 
         // adjacent rects
         expect(
             isRectInViewport(
                 rect(0, 0, 1, 1),
                 rect(-1, 0, 1, 1), // left
-                0,
             ),
         ).toBe(true);
         expect(
             isRectInViewport(
                 rect(0, 0, 1, 1),
                 rect(1, 0, 1, 1), // right
-                0,
             ),
         ).toBe(true);
         expect(
             isRectInViewport(
                 rect(0, 0, 1, 1),
                 rect(0, -1, 1, 1), // top
-                0,
             ),
         ).toBe(true);
         expect(
             isRectInViewport(
                 rect(0, 0, 1, 1),
                 rect(0, 1, 1, 1), // bottom
-                0,
             ),
         ).toBe(true);
 
@@ -145,28 +139,24 @@ describe("isRectInViewport", () => {
             isRectInViewport(
                 rect(0, 0, 1, 1),
                 rect(-2, 0, 1, 1), // 1px left
-                0,
             ),
         ).toBe(false);
         expect(
             isRectInViewport(
                 rect(0, 0, 1, 1),
                 rect(2, 0, 1, 1), // 1px right
-                0,
             ),
         ).toBe(false);
         expect(
             isRectInViewport(
                 rect(0, 0, 1, 1),
                 rect(0, -2, 1, 1), // 1px top
-                0,
             ),
         ).toBe(false);
         expect(
             isRectInViewport(
                 rect(0, 0, 1, 1),
                 rect(0, 2, 1, 1), // 1px bottom
-                0,
             ),
         ).toBe(false);
     });

--- a/packages/vfx-js/src/vfx-player.test.ts
+++ b/packages/vfx-js/src/vfx-player.test.ts
@@ -126,7 +126,7 @@ describe("isRectInViewport", () => {
                 pad(0),
                 0,
             ),
-        ).toBe(false);
+        ).toBe(true);
         expect(
             isRectInViewport(
                 rect(0, 0, 1, 1),
@@ -134,7 +134,7 @@ describe("isRectInViewport", () => {
                 pad(0),
                 0,
             ),
-        ).toBe(false);
+        ).toBe(true);
         expect(
             isRectInViewport(
                 rect(0, 0, 1, 1),
@@ -142,7 +142,7 @@ describe("isRectInViewport", () => {
                 pad(0),
                 0,
             ),
-        ).toBe(false);
+        ).toBe(true);
         expect(
             isRectInViewport(
                 rect(0, 0, 1, 1),
@@ -150,7 +150,7 @@ describe("isRectInViewport", () => {
                 pad(0),
                 0,
             ),
-        ).toBe(false);
+        ).toBe(true);
 
         // distant rects
         expect(
@@ -234,7 +234,7 @@ describe("isRectInViewport", () => {
                 pad(1),
                 0,
             ),
-        ).toBe(false);
+        ).toBe(true);
         expect(
             isRectInViewport(
                 rect(0, 0, 1, 1),
@@ -242,7 +242,7 @@ describe("isRectInViewport", () => {
                 pad(1),
                 0,
             ),
-        ).toBe(false);
+        ).toBe(true);
         expect(
             isRectInViewport(
                 rect(0, 0, 1, 1),
@@ -250,7 +250,7 @@ describe("isRectInViewport", () => {
                 pad(1),
                 0,
             ),
-        ).toBe(false);
+        ).toBe(true);
         expect(
             isRectInViewport(
                 rect(0, 0, 1, 1),
@@ -258,7 +258,7 @@ describe("isRectInViewport", () => {
                 pad(1),
                 0,
             ),
-        ).toBe(false);
+        ).toBe(true);
 
         // more distant rects
         expect(

--- a/packages/vfx-js/src/vfx-player.test.ts
+++ b/packages/vfx-js/src/vfx-player.test.ts
@@ -1,14 +1,14 @@
 import { expect, describe, test } from "vitest";
-import { isRectInViewport, sanitizeOverflow } from "./vfx-player";
+import { isRectInViewport, parseOverflowOpts } from "./vfx-player";
 import { RECT_ZERO } from "./rect";
 
-describe("sanitizeOverflow", () => {
+describe("parseOverflowOpts", () => {
     test('true => "fullscreen"', () => {
-        expect(sanitizeOverflow(true)).toStrictEqual([true, RECT_ZERO]);
+        expect(parseOverflowOpts(true)).toStrictEqual([true, RECT_ZERO]);
     });
 
     test("undefined => 0", () => {
-        expect(sanitizeOverflow(undefined)).toStrictEqual([
+        expect(parseOverflowOpts(undefined)).toStrictEqual([
             false,
             {
                 top: 0,
@@ -20,7 +20,7 @@ describe("sanitizeOverflow", () => {
     });
 
     test("number", () => {
-        expect(sanitizeOverflow(100)).toStrictEqual([
+        expect(parseOverflowOpts(100)).toStrictEqual([
             false,
             {
                 top: 100,
@@ -32,7 +32,7 @@ describe("sanitizeOverflow", () => {
     });
 
     test("number array", () => {
-        expect(sanitizeOverflow([0, 100, 200, 300])).toStrictEqual([
+        expect(parseOverflowOpts([0, 100, 200, 300])).toStrictEqual([
             false,
             {
                 top: 0,
@@ -44,7 +44,7 @@ describe("sanitizeOverflow", () => {
     });
 
     test("object", () => {
-        expect(sanitizeOverflow({})).toStrictEqual([
+        expect(parseOverflowOpts({})).toStrictEqual([
             false,
             {
                 top: 0,
@@ -53,7 +53,7 @@ describe("sanitizeOverflow", () => {
                 left: 0,
             },
         ]);
-        expect(sanitizeOverflow({ top: 100 })).toStrictEqual([
+        expect(parseOverflowOpts({ top: 100 })).toStrictEqual([
             false,
             {
                 top: 100,
@@ -62,7 +62,7 @@ describe("sanitizeOverflow", () => {
                 left: 0,
             },
         ]);
-        expect(sanitizeOverflow({ left: 100 })).toStrictEqual([
+        expect(parseOverflowOpts({ left: 100 })).toStrictEqual([
             false,
             {
                 top: 0,
@@ -71,7 +71,7 @@ describe("sanitizeOverflow", () => {
                 left: 100,
             },
         ]);
-        expect(sanitizeOverflow({ top: 100, left: 200 })).toStrictEqual([
+        expect(parseOverflowOpts({ top: 100, left: 200 })).toStrictEqual([
             false,
             {
                 top: 100,
@@ -81,7 +81,7 @@ describe("sanitizeOverflow", () => {
             },
         ]);
         expect(
-            sanitizeOverflow({ top: 100, right: 200, bottom: 300, left: 400 }),
+            parseOverflowOpts({ top: 100, right: 200, bottom: 300, left: 400 }),
         ).toStrictEqual([
             false,
             {

--- a/packages/vfx-js/src/vfx-player.ts
+++ b/packages/vfx-js/src/vfx-player.ts
@@ -466,7 +466,17 @@ export function isRectInViewport(
     threshold: number,
 ): boolean {
     const rect2 = growRect(rect, overflow);
-    return getIntersection(viewport, rect2) > threshold;
+    if (threshold === 0) {
+        // if threshold == 0, consider adjacent rects to be intersecting.
+        return (
+            rect2.left <= viewport.right &&
+            rect2.right >= viewport.left &&
+            rect2.top <= viewport.bottom &&
+            rect2.bottom >= viewport.top
+        );
+    } else {
+        return getIntersection(viewport, rect2) > threshold;
+    }
 }
 
 export function sanitizeOverflow(

--- a/packages/vfx-js/src/vfx-player.ts
+++ b/packages/vfx-js/src/vfx-player.ts
@@ -9,7 +9,7 @@ import {
     VFXUniformValue,
     VFXWrap,
 } from "./types";
-import { createRect, Rect, RECT_ZERO } from "./rect.js";
+import { createRect, growRect, Rect, RECT_ZERO } from "./rect.js";
 
 const gifFor = new Map<HTMLElement, GIFData>();
 
@@ -444,11 +444,12 @@ export function isRectInViewport(
     rect: Rect,
     overflow: Rect,
 ): boolean {
+    const rect2 = growRect(rect, overflow);
     return (
-        rect.left - overflow.left <= viewport.right &&
-        rect.right + overflow.right >= viewport.left &&
-        rect.top - overflow.top <= viewport.bottom &&
-        rect.bottom + overflow.bottom >= viewport.top
+        rect2.left <= viewport.right &&
+        rect2.right >= viewport.left &&
+        rect2.top <= viewport.bottom &&
+        rect2.bottom >= viewport.top
     );
 }
 

--- a/packages/vfx-js/src/vfx-player.ts
+++ b/packages/vfx-js/src/vfx-player.ts
@@ -173,14 +173,11 @@ export class VFXPlayer {
         const rect = element.getBoundingClientRect();
         const [isFullScreen, overflow] = sanitizeOverflow(opts.overflow);
         const intersection = sanitizeIntersection(opts.intersection);
+        const viewport = growRect(this.#viewport, intersection.rootMargin);
+
         const isInViewport =
             isFullScreen ||
-            isRectInViewport(
-                this.#viewport,
-                rect,
-                overflow,
-                intersection.threshold,
-            );
+            isRectInViewport(viewport, rect, overflow, intersection.threshold);
 
         const originalOpacity =
             element.style.opacity === ""
@@ -365,10 +362,14 @@ export class VFXPlayer {
             const rect = e.element.getBoundingClientRect();
 
             // Check intersection
+            const viewport = growRect(
+                this.#viewport,
+                e.intersection.rootMargin,
+            );
             const isInViewport =
                 e.isFullScreen ||
                 isRectInViewport(
-                    this.#viewport,
+                    viewport,
                     rect,
                     e.overflow,
                     e.intersection.threshold,
@@ -495,8 +496,10 @@ export function sanitizeIntersection(
     intersectionOpts: VFXProps["intersection"],
 ): VFXElementIntersection {
     const threshold = intersectionOpts?.threshold ?? 0;
+    const rootMargin = createRect(intersectionOpts?.rootMargin ?? 0);
     return {
         threshold,
+        rootMargin,
     };
 }
 

--- a/packages/vfx-js/src/vfx-player.ts
+++ b/packages/vfx-js/src/vfx-player.ts
@@ -172,9 +172,11 @@ export class VFXPlayer {
 
         const rect = element.getBoundingClientRect();
         const [isFullScreen, overflow] = sanitizeOverflow(opts.overflow);
+        const rectHitTest = growRect(rect, overflow);
+
         const intersection = sanitizeIntersection(opts.intersection);
         const isInViewport =
-            isFullScreen || isRectInViewport(this.#viewport, rect, overflow, 0);
+            isFullScreen || isRectInViewport(this.#viewport, rectHitTest, 0);
 
         const transitionArea = growRect(
             this.#viewport,
@@ -184,8 +186,7 @@ export class VFXPlayer {
             isFullScreen ||
             isRectInViewport(
                 transitionArea,
-                rect,
-                overflow,
+                rectHitTest,
                 intersection.threshold,
             );
 
@@ -371,11 +372,12 @@ export class VFXPlayer {
 
         for (const e of this.#elements) {
             const rect = e.element.getBoundingClientRect();
+            const rectHitTest = growRect(rect, e.overflow);
 
             // Check intersection
             const isInViewport =
                 e.isFullScreen ||
-                isRectInViewport(this.#viewport, rect, e.overflow, 0);
+                isRectInViewport(this.#viewport, rectHitTest, 0);
 
             const transitionArea = growRect(
                 this.#viewport,
@@ -385,8 +387,7 @@ export class VFXPlayer {
                 e.isFullScreen ||
                 isRectInViewport(
                     transitionArea,
-                    rect,
-                    e.overflow,
+                    rectHitTest,
                     e.intersection.threshold,
                 );
 
@@ -476,20 +477,18 @@ export class VFXPlayer {
 export function isRectInViewport(
     viewport: Rect,
     rect: Rect,
-    overflow: Rect,
     threshold: number,
 ): boolean {
-    const rect2 = growRect(rect, overflow);
     if (threshold === 0) {
         // if threshold == 0, consider adjacent rects to be intersecting.
         return (
-            rect2.left <= viewport.right &&
-            rect2.right >= viewport.left &&
-            rect2.top <= viewport.bottom &&
-            rect2.bottom >= viewport.top
+            rect.left <= viewport.right &&
+            rect.right >= viewport.left &&
+            rect.top <= viewport.bottom &&
+            rect.bottom >= viewport.top
         );
     } else {
-        return getIntersection(viewport, rect2) >= threshold;
+        return getIntersection(viewport, rect) >= threshold;
     }
 }
 

--- a/packages/vfx-js/src/vfx-player.ts
+++ b/packages/vfx-js/src/vfx-player.ts
@@ -476,7 +476,7 @@ export function isRectInViewport(
             rect2.bottom >= viewport.top
         );
     } else {
-        return getIntersection(viewport, rect2) > threshold;
+        return getIntersection(viewport, rect2) >= threshold;
     }
 }
 

--- a/packages/vfx-js/src/vfx-player.ts
+++ b/packages/vfx-js/src/vfx-player.ts
@@ -171,10 +171,10 @@ export class VFXPlayer {
         const shader = this.#getShader(opts.shader || "uvGradient");
 
         const rect = element.getBoundingClientRect();
-        const [isFullScreen, overflow] = sanitizeOverflow(opts.overflow);
+        const [isFullScreen, overflow] = parseOverflowOpts(opts.overflow);
         const rectHitTest = growRect(rect, overflow);
 
-        const intersection = sanitizeIntersection(opts.intersection);
+        const intersection = parseIntersectionOpts(opts.intersection);
         const isInViewport =
             isFullScreen || isRectInViewport(this.#viewport, rectHitTest);
 
@@ -506,7 +506,7 @@ export function checkIntersection(
     }
 }
 
-export function sanitizeOverflow(
+export function parseOverflowOpts(
     overflow: VFXProps["overflow"],
 ): [isFullScreen: boolean, Rect] {
     if (overflow === true) {
@@ -518,7 +518,7 @@ export function sanitizeOverflow(
     return [false, createRect(overflow)];
 }
 
-export function sanitizeIntersection(
+export function parseIntersectionOpts(
     intersectionOpts: VFXProps["intersection"],
 ): VFXElementIntersection {
     const threshold = intersectionOpts?.threshold ?? 0;

--- a/packages/vfx-js/src/vfx-player.ts
+++ b/packages/vfx-js/src/vfx-player.ts
@@ -252,6 +252,7 @@ export class VFXPlayer {
             enterTime: { value: -1.0 },
             leaveTime: { value: -1.0 },
             mouse: { value: new THREE.Vector2() },
+            intersection: { value: intersection },
         };
 
         const uniformGenerators: {
@@ -423,6 +424,7 @@ export class VFXPlayer {
                 this.#pixelRatio;
             e.uniforms["mouse"].value.x = this.#mouseX * this.#pixelRatio;
             e.uniforms["mouse"].value.y = this.#mouseY * this.#pixelRatio;
+            e.uniforms["intersection"].value = intersection;
 
             for (const [key, gen] of Object.entries(e.uniformGenerators)) {
                 e.uniforms[key].value = gen();

--- a/packages/vfx-js/src/vfx-player.ts
+++ b/packages/vfx-js/src/vfx-player.ts
@@ -10,18 +10,7 @@ import {
     VFXElementOverflow,
     VFXWrap,
 } from "./types";
-
-/**
- * top-left origin rect.
- * Subset of DOMRect, which is returned by `HTMLElement.getBoundingClientRect()`.
- * @internal
- */
-type Rect = {
-    left: number;
-    right: number;
-    top: number;
-    bottom: number;
-};
+import { createRect, Rect } from "./rect.js";
 
 const gifFor = new Map<HTMLElement, GIFData>();
 
@@ -477,28 +466,7 @@ export function sanitizeOverflow(
     if (overflow === undefined) {
         return { top: 0, right: 0, bottom: 0, left: 0 };
     }
-    if (typeof overflow === "number") {
-        return {
-            top: overflow,
-            right: overflow,
-            bottom: overflow,
-            left: overflow,
-        };
-    }
-    if (Array.isArray(overflow)) {
-        return {
-            top: overflow[0],
-            right: overflow[1],
-            bottom: overflow[2],
-            left: overflow[3],
-        };
-    }
-    return {
-        top: overflow.top ?? 0,
-        right: overflow.right ?? 0,
-        bottom: overflow.bottom ?? 0,
-        left: overflow.left ?? 0,
-    };
+    return createRect(overflow);
 }
 
 function parseWrapSingle(wrapOpt: VFXWrap): THREE.Wrapping {

--- a/packages/vfx-js/src/vfx-player.ts
+++ b/packages/vfx-js/src/vfx-player.ts
@@ -176,17 +176,19 @@ export class VFXPlayer {
 
         const intersection = sanitizeIntersection(opts.intersection);
         const isInViewport =
-            isFullScreen || isRectInViewport(this.#viewport, rectHitTest, 0);
+            isFullScreen || isRectInViewport(this.#viewport, rectHitTest);
 
         const transitionArea = growRect(
             this.#viewport,
             intersection.rootMargin,
         );
+        const intersectionRatio = getIntersection(this.#viewport, rectHitTest);
         const isInTransitionArea =
             isFullScreen ||
-            isRectInViewport(
+            checkIntersection(
                 transitionArea,
                 rectHitTest,
+                intersectionRatio,
                 intersection.threshold,
             );
 
@@ -376,18 +378,22 @@ export class VFXPlayer {
 
             // Check intersection
             const isInViewport =
-                e.isFullScreen ||
-                isRectInViewport(this.#viewport, rectHitTest, 0);
+                e.isFullScreen || isRectInViewport(this.#viewport, rectHitTest);
 
             const transitionArea = growRect(
                 this.#viewport,
                 e.intersection.rootMargin,
             );
+            const intersectionRatio = getIntersection(
+                transitionArea,
+                rectHitTest,
+            );
             const isInTransitionArea =
                 e.isFullScreen ||
-                isRectInViewport(
+                checkIntersection(
                     transitionArea,
                     rectHitTest,
+                    intersectionRatio,
                     e.intersection.threshold,
                 );
 
@@ -473,22 +479,30 @@ export class VFXPlayer {
     }
 }
 
-// TODO: Consider custom root element
-export function isRectInViewport(
+/**
+ * Returns if the given rects intersect.
+ * It returns true when the rects are adjacent (= intersection ratio is 0).
+ */
+export function isRectInViewport(viewport: Rect, rect: Rect): boolean {
+    return (
+        rect.left <= viewport.right &&
+        rect.right >= viewport.left &&
+        rect.top <= viewport.bottom &&
+        rect.bottom >= viewport.top
+    );
+}
+
+export function checkIntersection(
     viewport: Rect,
     rect: Rect,
+    intersection: number,
     threshold: number,
 ): boolean {
     if (threshold === 0) {
-        // if threshold == 0, consider adjacent rects to be intersecting.
-        return (
-            rect.left <= viewport.right &&
-            rect.right >= viewport.left &&
-            rect.top <= viewport.bottom &&
-            rect.bottom >= viewport.top
-        );
+        // if threshold === 0, consider adjacent rects to be intersecting.
+        return isRectInViewport(viewport, rect);
     } else {
-        return getIntersection(viewport, rect) >= threshold;
+        return intersection >= threshold;
     }
 }
 

--- a/packages/vfx-js/src/vfx-player.ts
+++ b/packages/vfx-js/src/vfx-player.ts
@@ -182,12 +182,12 @@ export class VFXPlayer {
             this.#viewport,
             intersectionOpts.rootMargin,
         );
-        const intersection = getIntersection(this.#viewport, rectHitTest);
+        const intersection = getIntersection(this.#viewport, rect);
         const isInLogicalViewport =
             isFullScreen ||
             checkIntersection(
                 logicalViewport,
-                rectHitTest,
+                rect,
                 intersection,
                 intersectionOpts.threshold,
             );
@@ -385,12 +385,12 @@ export class VFXPlayer {
                 this.#viewport,
                 e.intersection.rootMargin,
             );
-            const intersection = getIntersection(logicalViewport, rectHitTest);
+            const intersection = getIntersection(logicalViewport, rect);
             const isInLogicalViewport =
                 e.isFullScreen ||
                 checkIntersection(
                     logicalViewport,
-                    rectHitTest,
+                    rect,
                     intersection,
                     e.intersection.threshold,
                 );


### PR DESCRIPTION
This PR adds `VFXProps.intersection` to control transition shader behavior.
These property changes how element are considered to be entered to / left from the viewport.

```ts
type VFXProps = {
    /**
     * Options to control transition behaviour.
     * These properties work similarly to the IntersectionObsrever options.
     */
    intersection?: {
        /** Threshold for the element to be considered "entered" to the viewport. */
        threshold?: number;

        /** Margin of the viewport to be used in intersection calculcation. */
        rootMargin?: RectOpts;
    };
};
```

## Changes
- Added `VFXProps.intersection`
- Added new uniform value `uniform float intersection`
- Added new shader `focusTransition`