### PR TITLE
docs: fix GitHub file link

### DIFF
--- a/packages/docs-react-vfx/src/dom/UsageSection.tsx
+++ b/packages/docs-react-vfx/src/dom/UsageSection.tsx
@@ -118,7 +118,7 @@ const UsageSection: React.FC = () => (
                 VFX Elements have <InlineCode>shader</InlineCode> property. etc.
                 All available shaders are listed{" "}
                 <a
-                    href="https://github.com/fand/react-vfx/tree/master/src/constants.ts"
+                    href="https://github.com/fand/vfx-js/tree/main/packages/vfx-js/src/constants.ts"
                     target="_blank"
                     rel="noopener noreferrer"
                 >


### PR DESCRIPTION
This PR fixes the 404 link to GitHub caused by migration to monorepo.
ref. https://github.com/fand/vfx-js/issues/102