### PR TITLE
fix: update canvas size only if necessary

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -14,7 +14,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@vfx-js/core": "0.6.0",
+    "@vfx-js/core": "*",
     "@vfx-js/storybook": "0.0.8",
     "dedent": "^1.5.3",
     "is-mobile": "^5.0.0",

--- a/packages/vfx-js/src/vfx-player.ts
+++ b/packages/vfx-js/src/vfx-player.ts
@@ -47,6 +47,7 @@ export class VFXPlayer {
         top: 0,
         bottom: 0,
     };
+    #canvasSize = [0, 0];
 
     #mouseX = 0;
     #mouseY = 0;
@@ -108,7 +109,10 @@ export class VFXPlayer {
 
         const heightWithPadding = height + padding * 2;
 
-        if (width !== this.#width() || heightWithPadding !== this.#height()) {
+        if (
+            width !== this.#canvasSize[0] ||
+            heightWithPadding !== this.#canvasSize[1]
+        ) {
             this.#canvas.width = width;
             this.#canvas.height = heightWithPadding;
             this.#renderer.setSize(width, heightWithPadding);
@@ -117,8 +121,9 @@ export class VFXPlayer {
                 top: -padding,
                 left: 0,
                 right: width,
-                bottom: height + padding,
+                bottom: height,
             };
+            this.#canvasSize = [width, heightWithPadding];
         }
 
         // Sync scroll
@@ -128,14 +133,6 @@ export class VFXPlayer {
                 `translate(0, ${scroll - padding}px)`,
             );
         }
-    }
-
-    #width(): number {
-        return this.#viewport.right - this.#viewport.left;
-    }
-
-    #height(): number {
-        return this.#viewport.bottom - this.#viewport.top;
     }
 
     #resize = async (): Promise<void> => {

--- a/packages/vfx-js/src/vfx-player.ts
+++ b/packages/vfx-js/src/vfx-player.ts
@@ -117,7 +117,7 @@ export class VFXPlayer {
                 top: -padding,
                 left: 0,
                 right: width,
-                bottom: height,
+                bottom: height + padding,
             };
         }
 


### PR DESCRIPTION
After #115 , VFX-JS tries to resize the canvas every frame unnecessarily.
This PR fixes the problem by storing the actual canvas size for resize detection, apart from the viewport settings.