### PR TITLE
feat: crop input texture with `VFXProps.autoCrop`

### DIFF
--- a/packages/storybook/src/Layout.stories.ts
+++ b/packages/storybook/src/Layout.stories.ts
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from "@storybook/html";
 
 import { initVFX } from "./utils";
 import Logo from "./assets/logo-640w-20p.svg";
+import LogoWithoutPadding from "./assets/logo-no-padding.svg";
 import "./preset.css";
 
 const shader = `
@@ -282,3 +283,18 @@ const wrapBase = (
 export const wrapRepeat = wrapBase("repeat");
 export const wrapClamp = wrapBase("clamp");
 export const wrapMirror = wrapBase("mirror");
+
+export const autoCrop = {
+    render: ({ autoCrop }: { autoCrop: boolean }) => {
+        const img = document.createElement("img");
+        img.src = LogoWithoutPadding;
+
+        const vfx = initVFX();
+        vfx.add(img, { autoCrop, overflow: 200 });
+
+        return img;
+    },
+    args: {
+        autoCrop: true,
+    },
+};

--- a/packages/storybook/src/Layout.stories.ts
+++ b/packages/storybook/src/Layout.stories.ts
@@ -2,8 +2,9 @@ import type { VFXProps, shaders } from "@vfx-js/core";
 import type { Meta, StoryObj } from "@storybook/html";
 
 import { initVFX } from "./utils";
+import { Timer } from "./Timer";
 import Logo from "./assets/logo-640w-20p.svg";
-import LogoWithoutPadding from "./assets/logo-no-padding.svg";
+import Jellyfish from "./assets/jellyfish.webp";
 import "./preset.css";
 
 const shader = `
@@ -285,16 +286,27 @@ export const wrapClamp = wrapBase("clamp");
 export const wrapMirror = wrapBase("mirror");
 
 export const autoCrop = {
-    render: ({ autoCrop }: { autoCrop: boolean }) => {
+    render: ({ shader, autoCrop }: { shader: string; autoCrop: boolean }) => {
+        const timer = new Timer(0, [0, 10]);
+        document.body.append(timer.element);
+
         const img = document.createElement("img");
-        img.src = LogoWithoutPadding;
+        img.src = Jellyfish;
 
         const vfx = initVFX();
-        vfx.add(img, { autoCrop, overflow: 200 });
+        vfx.add(img, {
+            shader,
+            autoCrop,
+            overflow: 200,
+            uniforms: {
+                time: () => timer.time,
+            },
+        });
 
         return img;
     },
     args: {
+        shader: "rainbow",
         autoCrop: true,
     },
 };

--- a/packages/vfx-js/src/constants.ts
+++ b/packages/vfx-js/src/constants.ts
@@ -47,9 +47,12 @@ export type ShaderPreset =
     | "pixelateTransition"
     | "focusTransition";
 
-const AUTO_CROP = `
-if (autoCrop && uv.x < 0. || uv.x > 1. || uv.y < 0. || uv.y > 1.) { outColor = vec4(0); return; }
-`;
+const READ_TEX = `vec4 readTex(sampler2D tex, vec2 uv) {
+    if (autoCrop && (uv.x < 0. || uv.x > 1. || uv.y < 0. || uv.y > 1.)) {
+        return vec4(0);
+    }
+    return texture(tex, uv);
+}`;
 
 /**
  * Shader code for presets.
@@ -70,12 +73,13 @@ export const shaders: Record<ShaderPreset, string> = {
     uniform sampler2D src;
     out vec4 outColor;
 
+    ${READ_TEX}
+
     void main() {
         vec2 uv = (gl_FragCoord.xy - offset) / resolution;
-        ${AUTO_CROP}
         outColor = vec4(uv, sin(time) * .5 + .5, 1);
 
-        vec4 img = texture(src, uv);
+        vec4 img = readTex(src, uv);
         outColor *= smoothstep(0., 1., img.a);
     }
     `,
@@ -84,8 +88,11 @@ export const shaders: Record<ShaderPreset, string> = {
     uniform vec2 resolution;
     uniform vec2 offset;
     uniform float time;
+    uniform bool autoCrop;
     uniform sampler2D src;
     out vec4 outColor;
+
+    ${READ_TEX}
 
     vec3 hsv2rgb(vec3 c) {
         vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
@@ -116,7 +123,7 @@ export const shaders: Record<ShaderPreset, string> = {
 
         float x = (uv2.x - uv2.y) - fract(time);
 
-        vec4 img = texture(src, uv);
+        vec4 img = readTex(src, uv);
         float gray = length(img.rgb);
 
         img.rgb = vec3(hueShift(vec3(1,0,0), x) * gray);
@@ -129,8 +136,11 @@ export const shaders: Record<ShaderPreset, string> = {
     uniform vec2 resolution;
     uniform vec2 offset;
     uniform float time;
+    uniform bool autoCrop;
     uniform sampler2D src;
     out vec4 outColor;
+
+    ${READ_TEX}
 
     float nn(float y, float t) {
         float n = (
@@ -142,11 +152,6 @@ export const shaders: Record<ShaderPreset, string> = {
         n += sin(y * 124. + t * 100.7) * sin(y * 877. - t * 38.8) * .3;
 
         return n;
-    }
-
-    vec4 readTex(sampler2D tex, vec2 uv) {
-        if (uv.x < 0. || uv.x > 1. || uv.y < 0. || uv.y > 1.) { return vec4(0); }
-        return texture(tex, uv);
     }
 
     void main (void) {
@@ -204,15 +209,18 @@ export const shaders: Record<ShaderPreset, string> = {
     uniform vec2 resolution;
     uniform vec2 offset;
     uniform float time;
+    uniform bool autoCrop;
     uniform sampler2D src;
     out vec4 outColor;
+
+    ${READ_TEX}
 
     void main (void) {
         vec2 uv = (gl_FragCoord.xy - offset) / resolution;
 
         float b = sin(time * 2.) * 32. + 48.;
         uv = floor(uv * b) / b;
-        outColor = texture(src, uv);
+        outColor = readTex(src, uv);
     }
     `,
     rgbGlitch: `
@@ -220,8 +228,11 @@ export const shaders: Record<ShaderPreset, string> = {
     uniform vec2 resolution;
     uniform vec2 offset;
     uniform float time;
+    uniform bool autoCrop;
     uniform sampler2D src;
     out vec4 outColor;
+
+    ${READ_TEX}
 
     float random(vec2 st) {
         return fract(sin(dot(st, vec2(948.,824.))) * 30284.);
@@ -251,9 +262,9 @@ export const shaders: Record<ShaderPreset, string> = {
             }
         }
 
-        vec4 cr = texture(src, uvr);
-        vec4 cg = texture(src, uvg);
-        vec4 cb = texture(src, uvb);
+        vec4 cr = readTex(src, uvr);
+        vec4 cg = readTex(src, uvg);
+        vec4 cb = readTex(src, uvb);
 
         outColor = vec4(
             cr.r,
@@ -268,8 +279,11 @@ export const shaders: Record<ShaderPreset, string> = {
     uniform vec2 resolution;
     uniform vec2 offset;
     uniform float time;
+    uniform bool autoCrop;
     uniform sampler2D src;
     out vec4 outColor;
+
+    ${READ_TEX}
 
     float nn(float y, float t) {
         float n = (
@@ -287,10 +301,6 @@ export const shaders: Record<ShaderPreset, string> = {
         return step(t, uv.x) * step(t, uv.y);
     }
 
-    float inside(vec2 uv) {
-        return step2(0., uv) * step2(0., 1. - uv);
-    }
-
     void main (void) {
         vec2 uv = (gl_FragCoord.xy - offset) / resolution;
         vec2 uvr = uv, uvg = uv, uvb = uv;
@@ -305,9 +315,9 @@ export const shaders: Record<ShaderPreset, string> = {
             uvb.x += nn(uv.y, t + 20.) * amp;
         }
 
-        vec4 cr = texture(src, uvr) * inside(uvr);
-        vec4 cg = texture(src, uvg) * inside(uvg);
-        vec4 cb = texture(src, uvb) * inside(uvb);
+        vec4 cr = readTex(src, uvr);
+        vec4 cg = readTex(src, uvg);
+        vec4 cb = readTex(src, uvb);
 
         outColor = vec4(
             cr.r,
@@ -325,8 +335,11 @@ export const shaders: Record<ShaderPreset, string> = {
     uniform vec2 resolution;
     uniform vec2 offset;
     uniform float time;
+    uniform bool autoCrop;
     uniform sampler2D src;
     out vec4 outColor;
+
+    ${READ_TEX}
 
     // TODO: uniform
     #define gridSize 10.0
@@ -334,7 +347,7 @@ export const shaders: Record<ShaderPreset, string> = {
     #define smoothing 0.15
     #define speed 1.0
 
-    #define IMG_PIXEL(x, y) texture(x, (y - offset) / resolution);
+    #define IMG_PIXEL(x, y) readTex(x, (y - offset) / resolution);
 
     vec4 gridRot = vec4(15.0, 45.0, 75.0, 0.0);
 
@@ -416,7 +429,7 @@ export const shaders: Record<ShaderPreset, string> = {
         }
 
         vec2 uv = (gl_FragCoord.xy - offset) / resolution;
-        vec4 original = texture(src, uv);
+        vec4 original = readTex(src, uv);
         float alpha = step(.1, rgbAmounts[0] + rgbAmounts[1] + rgbAmounts[2] + original.a);
 
         outColor = vec4(rgbAmounts[0], rgbAmounts[1], rgbAmounts[2], alpha);
@@ -427,12 +440,11 @@ export const shaders: Record<ShaderPreset, string> = {
     uniform vec2 resolution;
     uniform vec2 offset;
     uniform float time;
+    uniform bool autoCrop;
     uniform sampler2D src;
     out vec4 outColor;
 
-    float inside(in vec2 uv) {
-        return step(0., uv.x) * step(uv.x, 1.) * step(0., uv.y) * step(uv.y, 1.);
-    }
+    ${READ_TEX}
 
     vec4 draw(vec2 uv) {
         vec2 uvr = uv, uvg = uv, uvb = uv;
@@ -443,9 +455,9 @@ export const shaders: Record<ShaderPreset, string> = {
         uvg.x += sin(uv.y * 7. + time * 3. + .4) * amp;
         uvb.x += sin(uv.y * 7. + time * 3. + .8) * amp;
 
-        vec4 cr = texture(src, uvr) * inside(uvr);
-        vec4 cg = texture(src, uvg) * inside(uvg);
-        vec4 cb = texture(src, uvb) * inside(uvb);
+        vec4 cr = readTex(src, uvr);
+        vec4 cg = readTex(src, uvg);
+        vec4 cb = readTex(src, uvb);
 
         return vec4(
             cr.r,
@@ -468,8 +480,11 @@ export const shaders: Record<ShaderPreset, string> = {
     uniform vec2 resolution;
     uniform vec2 offset;
     uniform float time;
+    uniform bool autoCrop;
     uniform sampler2D src;
     out vec4 outColor;
+
+    ${READ_TEX}
 
     void main (void) {
         vec2 uv = (gl_FragCoord.xy - offset) / resolution;
@@ -477,7 +492,7 @@ export const shaders: Record<ShaderPreset, string> = {
         vec2 p = uv * 2. - 1.;
         float a = atan(p.y, p.x);
 
-        vec4 col = texture(src, uv);
+        vec4 col = readTex(src, uv);
         float gray = length(col.rgb);
 
         float level = 1. + sin(a * 10. + time * 3.) * 0.2;
@@ -490,13 +505,16 @@ export const shaders: Record<ShaderPreset, string> = {
     uniform vec2 resolution;
     uniform vec2 offset;
     uniform float time;
+    uniform bool autoCrop;
     uniform sampler2D src;
     out vec4 outColor;
+
+    ${READ_TEX}
 
     void main (void) {
         vec2 uv = (gl_FragCoord.xy - offset) / resolution;
 
-        outColor = texture(src, uv) * (sin(time * 5.) * 0.2 + 0.8);
+        outColor = readTex(src, uv) * (sin(time * 5.) * 0.2 + 0.8);
     }
 
     `,
@@ -505,16 +523,16 @@ export const shaders: Record<ShaderPreset, string> = {
     uniform vec2 resolution;
     uniform vec2 offset;
     uniform float time;
+    uniform bool autoCrop;
     uniform sampler2D src;
     out vec4 outColor;
+
+    ${READ_TEX}
 
     void main (void) {
         vec2 uv = (gl_FragCoord.xy - offset) / resolution;
         uv = (uv - .5) * (1.05 + sin(time * 5.) * 0.05) + .5;
-
-        if (uv.x < 0. || uv.x > 1. || uv.y < 0. || uv.y > 1.) { discard; }
-
-        outColor = texture(src, uv);
+        outColor = readTex(src, uv);
     }
     `,
     duotone: `
@@ -522,15 +540,18 @@ export const shaders: Record<ShaderPreset, string> = {
     uniform vec2 resolution;
     uniform vec2 offset;
     uniform float time;
+    uniform bool autoCrop;
     uniform sampler2D src;
     uniform vec4 color1;
     uniform vec4 color2;
     uniform float speed;
     out vec4 outColor;
 
+    ${READ_TEX}
+
     void main (void) {
         vec2 uv = (gl_FragCoord.xy - offset) / resolution;
-        vec4 color = texture(src, uv);
+        vec4 color = readTex(src, uv);
 
         float gray = dot(color.rgb, vec3(0.2, 0.7, 0.08));
         float t = mod(gray * 2.0 + time * speed, 2.0);
@@ -549,6 +570,7 @@ export const shaders: Record<ShaderPreset, string> = {
     uniform vec2 resolution;
     uniform vec2 offset;
     uniform float time;
+    uniform bool autoCrop;
     uniform sampler2D src;
     uniform vec4 color1;
     uniform vec4 color2;
@@ -556,9 +578,11 @@ export const shaders: Record<ShaderPreset, string> = {
     uniform float speed;
     out vec4 outColor;
 
+    ${READ_TEX}
+
     void main (void) {
         vec2 uv = (gl_FragCoord.xy - offset) / resolution;
-        vec4 color = texture(src, uv);
+        vec4 color = readTex(src, uv);
 
         float gray = dot(color.rgb, vec3(0.2, 0.7, 0.08));
         float t = mod(gray * 3.0 + time * speed, 3.0);
@@ -579,9 +603,12 @@ export const shaders: Record<ShaderPreset, string> = {
     uniform vec2 resolution;
     uniform vec2 offset;
     uniform float time;
+    uniform bool autoCrop;
     uniform sampler2D src;
     uniform float shift;
     out vec4 outColor;
+
+    ${READ_TEX}
 
     vec3 hsv2rgb(vec3 c) {
         vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
@@ -607,7 +634,7 @@ export const shaders: Record<ShaderPreset, string> = {
 
     void main (void) {
         vec2 uv = (gl_FragCoord.xy - offset) / resolution;
-        vec4 color = texture(src, uv);
+        vec4 color = readTex(src, uv);
         color.rgb = hueShift(color.rgb, shift);
         outColor = color;
     }
@@ -619,8 +646,11 @@ export const shaders: Record<ShaderPreset, string> = {
     uniform float time;
     uniform float enterTime;
     uniform float leaveTime;
+    uniform bool autoCrop;
     uniform sampler2D src;
     out vec4 outColor;
+
+    ${READ_TEX}
 
     #define DURATION 1.0
 
@@ -639,7 +669,7 @@ export const shaders: Record<ShaderPreset, string> = {
             uv.x += sin(floor(uv.y * 300.)) * 3. * exp(t * -10.);
         }
 
-        outColor = texture(src, uv);
+        outColor = readTex(src, uv);
     }
     `,
     slitScanTransition: `
@@ -649,8 +679,11 @@ export const shaders: Record<ShaderPreset, string> = {
     uniform float time;
     uniform float enterTime;
     uniform float leaveTime;
+    uniform bool autoCrop;
     uniform sampler2D src;
     out vec4 outColor;
+
+    ${READ_TEX}
 
     #define DURATION 1.0
 
@@ -675,7 +708,7 @@ export const shaders: Record<ShaderPreset, string> = {
             uv.y = uv.y < t ? t : uv.y;
         }
 
-        outColor = texture(src, uv);
+        outColor = readTex(src, uv);
     }
     `,
     pixelateTransition: `
@@ -685,8 +718,11 @@ export const shaders: Record<ShaderPreset, string> = {
     uniform float time;
     uniform float enterTime;
     uniform float leaveTime;
+    uniform bool autoCrop;
     uniform sampler2D src;
     out vec4 outColor;
+
+    ${READ_TEX}
 
     #define DURATION 1.0
 
@@ -704,7 +740,7 @@ export const shaders: Record<ShaderPreset, string> = {
             uv = (floor(uv * b) + .5) / b;
         }
 
-        outColor = texture(src, uv);
+        outColor = readTex(src, uv);
     }
     `,
     focusTransition: `
@@ -713,16 +749,19 @@ export const shaders: Record<ShaderPreset, string> = {
     uniform vec2 offset;
     uniform float time;
     uniform float intersection;
+    uniform bool autoCrop;
     uniform sampler2D src;
     out vec4 outColor;
+
+    ${READ_TEX}
 
     void main (void) {
         vec2 uv = (gl_FragCoord.xy - offset) / resolution;
         float t = smoothstep(0., 1., intersection);
 
         outColor = mix(
-            texture(src, uv + vec2(1. - t, 0)),
-            texture(src, uv + vec2(-(1. - t), 0)),
+            readTex(src, uv + vec2(1. - t, 0)),
+            readTex(src, uv + vec2(-(1. - t), 0)),
             0.5
         ) * intersection;
     }

--- a/packages/vfx-js/src/constants.ts
+++ b/packages/vfx-js/src/constants.ts
@@ -47,6 +47,10 @@ export type ShaderPreset =
     | "pixelateTransition"
     | "focusTransition";
 
+const AUTO_CROP = `
+if (autoCrop && uv.x < 0. || uv.x > 1. || uv.y < 0. || uv.y > 1.) { outColor = vec4(0); return; }
+`;
+
 /**
  * Shader code for presets.
  * Shaders in `shader` can be looked up with keys in `ShaderPreset`.
@@ -62,11 +66,13 @@ export const shaders: Record<ShaderPreset, string> = {
     uniform vec2 resolution;
     uniform vec2 offset;
     uniform float time;
+    uniform bool autoCrop;
     uniform sampler2D src;
     out vec4 outColor;
+
     void main() {
         vec2 uv = (gl_FragCoord.xy - offset) / resolution;
-
+        ${AUTO_CROP}
         outColor = vec4(uv, sin(time) * .5 + .5, 1);
 
         vec4 img = texture(src, uv);

--- a/packages/vfx-js/src/constants.ts
+++ b/packages/vfx-js/src/constants.ts
@@ -47,6 +47,15 @@ export type ShaderPreset =
     | "pixelateTransition"
     | "focusTransition";
 
+const COMMON_HEADER = `precision highp float;
+uniform vec2 resolution;
+uniform vec2 offset;
+uniform float time;
+uniform bool autoCrop;
+uniform sampler2D src;
+out vec4 outColor;
+`;
+
 const READ_TEX = `vec4 readTex(sampler2D tex, vec2 uv) {
     if (autoCrop && (uv.x < 0. || uv.x > 1. || uv.y < 0. || uv.y > 1.)) {
         return vec4(0);
@@ -65,14 +74,7 @@ const READ_TEX = `vec4 readTex(sampler2D tex, vec2 uv) {
  */
 export const shaders: Record<ShaderPreset, string> = {
     uvGradient: `
-    precision highp float;
-    uniform vec2 resolution;
-    uniform vec2 offset;
-    uniform float time;
-    uniform bool autoCrop;
-    uniform sampler2D src;
-    out vec4 outColor;
-
+    ${COMMON_HEADER}
     ${READ_TEX}
 
     void main() {
@@ -84,14 +86,7 @@ export const shaders: Record<ShaderPreset, string> = {
     }
     `,
     rainbow: `
-    precision highp float;
-    uniform vec2 resolution;
-    uniform vec2 offset;
-    uniform float time;
-    uniform bool autoCrop;
-    uniform sampler2D src;
-    out vec4 outColor;
-
+    ${COMMON_HEADER}
     ${READ_TEX}
 
     vec3 hsv2rgb(vec3 c) {
@@ -132,14 +127,7 @@ export const shaders: Record<ShaderPreset, string> = {
     }
     `,
     glitch: `
-    precision highp float;
-    uniform vec2 resolution;
-    uniform vec2 offset;
-    uniform float time;
-    uniform bool autoCrop;
-    uniform sampler2D src;
-    out vec4 outColor;
-
+    ${COMMON_HEADER}
     ${READ_TEX}
 
     float nn(float y, float t) {
@@ -205,14 +193,7 @@ export const shaders: Record<ShaderPreset, string> = {
     }
     `,
     pixelate: `
-    precision highp float;
-    uniform vec2 resolution;
-    uniform vec2 offset;
-    uniform float time;
-    uniform bool autoCrop;
-    uniform sampler2D src;
-    out vec4 outColor;
-
+    ${COMMON_HEADER}
     ${READ_TEX}
 
     void main (void) {
@@ -224,14 +205,7 @@ export const shaders: Record<ShaderPreset, string> = {
     }
     `,
     rgbGlitch: `
-    precision highp float;
-    uniform vec2 resolution;
-    uniform vec2 offset;
-    uniform float time;
-    uniform bool autoCrop;
-    uniform sampler2D src;
-    out vec4 outColor;
-
+    ${COMMON_HEADER}
     ${READ_TEX}
 
     float random(vec2 st) {
@@ -275,14 +249,7 @@ export const shaders: Record<ShaderPreset, string> = {
     }
     `,
     rgbShift: `
-    precision highp float;
-    uniform vec2 resolution;
-    uniform vec2 offset;
-    uniform float time;
-    uniform bool autoCrop;
-    uniform sampler2D src;
-    out vec4 outColor;
-
+    ${COMMON_HEADER}
     ${READ_TEX}
 
     float nn(float y, float t) {
@@ -331,14 +298,7 @@ export const shaders: Record<ShaderPreset, string> = {
     // Halftone Effect by zoidberg
     // https://www.interactiveshaderformat.com/sketches/234
 
-    precision highp float;
-    uniform vec2 resolution;
-    uniform vec2 offset;
-    uniform float time;
-    uniform bool autoCrop;
-    uniform sampler2D src;
-    out vec4 outColor;
-
+    ${COMMON_HEADER}
     ${READ_TEX}
 
     // TODO: uniform
@@ -436,14 +396,7 @@ export const shaders: Record<ShaderPreset, string> = {
     }
     `,
     sinewave: `
-    precision highp float;
-    uniform vec2 resolution;
-    uniform vec2 offset;
-    uniform float time;
-    uniform bool autoCrop;
-    uniform sampler2D src;
-    out vec4 outColor;
-
+    ${COMMON_HEADER}
     ${READ_TEX}
 
     vec4 draw(vec2 uv) {
@@ -476,14 +429,7 @@ export const shaders: Record<ShaderPreset, string> = {
     }
     `,
     shine: `
-    precision highp float;
-    uniform vec2 resolution;
-    uniform vec2 offset;
-    uniform float time;
-    uniform bool autoCrop;
-    uniform sampler2D src;
-    out vec4 outColor;
-
+    ${COMMON_HEADER}
     ${READ_TEX}
 
     void main (void) {
@@ -501,14 +447,7 @@ export const shaders: Record<ShaderPreset, string> = {
     }
     `,
     blink: `
-    precision highp float;
-    uniform vec2 resolution;
-    uniform vec2 offset;
-    uniform float time;
-    uniform bool autoCrop;
-    uniform sampler2D src;
-    out vec4 outColor;
-
+    ${COMMON_HEADER}
     ${READ_TEX}
 
     void main (void) {
@@ -519,14 +458,7 @@ export const shaders: Record<ShaderPreset, string> = {
 
     `,
     spring: `
-    precision highp float;
-    uniform vec2 resolution;
-    uniform vec2 offset;
-    uniform float time;
-    uniform bool autoCrop;
-    uniform sampler2D src;
-    out vec4 outColor;
-
+    ${COMMON_HEADER}
     ${READ_TEX}
 
     void main (void) {
@@ -536,18 +468,12 @@ export const shaders: Record<ShaderPreset, string> = {
     }
     `,
     duotone: `
-    precision highp float;
-    uniform vec2 resolution;
-    uniform vec2 offset;
-    uniform float time;
-    uniform bool autoCrop;
-    uniform sampler2D src;
+    ${COMMON_HEADER}
+    ${READ_TEX}
+
     uniform vec4 color1;
     uniform vec4 color2;
     uniform float speed;
-    out vec4 outColor;
-
-    ${READ_TEX}
 
     void main (void) {
         vec2 uv = (gl_FragCoord.xy - offset) / resolution;
@@ -566,19 +492,13 @@ export const shaders: Record<ShaderPreset, string> = {
     }
     `,
     tritone: `
-    precision highp float;
-    uniform vec2 resolution;
-    uniform vec2 offset;
-    uniform float time;
-    uniform bool autoCrop;
-    uniform sampler2D src;
+    ${COMMON_HEADER}
+    ${READ_TEX}
+
     uniform vec4 color1;
     uniform vec4 color2;
     uniform vec4 color3;
     uniform float speed;
-    out vec4 outColor;
-
-    ${READ_TEX}
 
     void main (void) {
         vec2 uv = (gl_FragCoord.xy - offset) / resolution;
@@ -599,16 +519,10 @@ export const shaders: Record<ShaderPreset, string> = {
     }
     `,
     hueShift: `
-    precision highp float;
-    uniform vec2 resolution;
-    uniform vec2 offset;
-    uniform float time;
-    uniform bool autoCrop;
-    uniform sampler2D src;
-    uniform float shift;
-    out vec4 outColor;
-
+    ${COMMON_HEADER}
     ${READ_TEX}
+
+    uniform float shift;
 
     vec3 hsv2rgb(vec3 c) {
         vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
@@ -640,15 +554,9 @@ export const shaders: Record<ShaderPreset, string> = {
     }
     `,
     warpTransition: `
-    precision highp float;
-    uniform vec2 resolution;
-    uniform vec2 offset;
-    uniform float time;
+    ${COMMON_HEADER}
     uniform float enterTime;
     uniform float leaveTime;
-    uniform bool autoCrop;
-    uniform sampler2D src;
-    out vec4 outColor;
 
     ${READ_TEX}
 
@@ -673,17 +581,11 @@ export const shaders: Record<ShaderPreset, string> = {
     }
     `,
     slitScanTransition: `
-    precision highp float;
-    uniform vec2 resolution;
-    uniform vec2 offset;
-    uniform float time;
+    ${COMMON_HEADER}
+    ${READ_TEX}
+
     uniform float enterTime;
     uniform float leaveTime;
-    uniform bool autoCrop;
-    uniform sampler2D src;
-    out vec4 outColor;
-
-    ${READ_TEX}
 
     #define DURATION 1.0
 
@@ -712,17 +614,11 @@ export const shaders: Record<ShaderPreset, string> = {
     }
     `,
     pixelateTransition: `
-    precision highp float;
-    uniform vec2 resolution;
-    uniform vec2 offset;
-    uniform float time;
+    ${COMMON_HEADER}
+    ${READ_TEX}
+
     uniform float enterTime;
     uniform float leaveTime;
-    uniform bool autoCrop;
-    uniform sampler2D src;
-    out vec4 outColor;
-
-    ${READ_TEX}
 
     #define DURATION 1.0
 
@@ -744,16 +640,10 @@ export const shaders: Record<ShaderPreset, string> = {
     }
     `,
     focusTransition: `
-    precision highp float;
-    uniform vec2 resolution;
-    uniform vec2 offset;
-    uniform float time;
-    uniform float intersection;
-    uniform bool autoCrop;
-    uniform sampler2D src;
-    out vec4 outColor;
-
+    ${COMMON_HEADER}
     ${READ_TEX}
+
+    uniform float intersection;
 
     void main (void) {
         vec2 uv = (gl_FragCoord.xy - offset) / resolution;

--- a/packages/vfx-js/src/types.ts
+++ b/packages/vfx-js/src/types.ts
@@ -219,6 +219,11 @@ export type VFXProps = {
      * Whether the shader uses the backbuffer or not.
      */
     backbuffer?: boolean;
+
+    /**
+     * auto
+     */
+    autoCrop?: boolean;
 };
 
 /**
@@ -274,6 +279,7 @@ export type VFXElement = {
     originalOpacity: number;
     zIndex: number;
     backbuffer?: Backbuffer;
+    autoCrop: boolean;
 };
 
 export type VFXElementIntersection = {

--- a/packages/vfx-js/src/types.ts
+++ b/packages/vfx-js/src/types.ts
@@ -221,7 +221,11 @@ export type VFXProps = {
     backbuffer?: boolean;
 
     /**
-     * auto
+     * Whether the input texture should be cropped to the element bounds. (Default: `true`)
+     * If `true`, The preset shaders will crop the input texture automatically.
+     *
+     * Note: if you use custom shaders, you have to implement the cropping manually.
+     * VFX-JS provides `uniform bool autoCrop;` to help this.
      */
     autoCrop?: boolean;
 };

--- a/packages/vfx-js/src/vfx-player.ts
+++ b/packages/vfx-js/src/vfx-player.ts
@@ -308,6 +308,8 @@ export class VFXPlayer {
         texture.format = THREE.RGBAFormat;
         texture.needsUpdate = true;
 
+        const autoCrop = opts.autoCrop ?? true;
+
         // Hide original element
         if (opts.overlay === true) {
             /* Overlay mode. Do not hide the element */
@@ -330,6 +332,7 @@ export class VFXPlayer {
             mouse: { value: new THREE.Vector2() },
             intersection: { value: 0.0 },
             viewport: { value: new THREE.Vector4() },
+            autoCrop: { value: autoCrop },
         };
 
         const uniformGenerators: {
@@ -401,6 +404,7 @@ export class VFXPlayer {
             originalOpacity,
             zIndex: opts.zIndex ?? 0,
             backbuffer,
+            autoCrop,
         };
 
         this.#hitTest(elem, rect, now);


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a6ab0fae-f289-42b9-b760-1f3e8f3b67b3)

Currently, the shaders in VFX-JS uses the input texture without cropping.
When the input image/video has colored pixels at the edge, it causes a clamping effect, especially noticeable when the element has `overflow`.

Unfortunately, we can't fix this simply with WebGL settings.
OpenGL has a texture wrapping mode named `CLAMP_TO_BORDER`, however it's not available on WebGL.

This PR solves the issue by adding a new property `autoCrop: boolean` (default: true).
If this flag is enabled, the preset shaders will crop the input texture automatically in the range of `0.0 < uv <= 1.0`.


## Changes
- Add `VFXProps.autoCrop` (default: true)
- Crop input texture when `autoCrop` is enabled